### PR TITLE
Use strlcpy instead strncpy

### DIFF
--- a/sound/soc/msm/AW87319_Audio_M.c
+++ b/sound/soc/msm/AW87319_Audio_M.c
@@ -377,7 +377,7 @@ static int aw87319_i2c_probe(struct i2c_client *client, const struct i2c_device_
 	if (!cnt) {
 		err = -ENODEV;
 		aw87319_hw_off();
-		strncpy(Spk_Pa_Flag, "S88537A12", 9);
+		strlcpy(Spk_Pa_Flag, "S88537A12", 9);
 		pr_err("%s:can not find AW87319, board  is S88537A12\n!", __func__);
 		goto exit_create_singlethread;
 	}


### PR DESCRIPTION
This ensures that the result string will be null-terminated.